### PR TITLE
EASY-1339: polygon in datacite v4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <inceptionYear>2014</inceptionYear>
 
     <properties>
-        <easy.emd.version>3.5</easy.emd.version>
+        <easy.emd.version>3.6</easy.emd.version>
     </properties>
 
     <scm>

--- a/src/main/resources/xslt-files/EMD_doi_datacite_v4.xsl
+++ b/src/main/resources/xslt-files/EMD_doi_datacite_v4.xsl
@@ -823,8 +823,10 @@
         <!-- Ignore coordinates in degrees for now. -->
         <xsl:apply-templates select="eas:point[@eas:scheme = 'RD']"/>
         <xsl:apply-templates select="eas:box[@eas:scheme = 'RD']"/>
+        <xsl:apply-templates select="eas:polygon[@eas:scheme = 'RD']/eas:polygon-exterior"/>
         <xsl:apply-templates select="eas:point[@eas:scheme = 'degrees']"/>
         <xsl:apply-templates select="eas:box[@eas:scheme = 'degrees']"/>
+        <xsl:apply-templates select="eas:polygon[@eas:scheme = 'degrees']/eas:polygon-exterior"/>
     </xsl:template>
     <!-- =================================================================================== -->
     <xsl:template match="eas:point[@eas:scheme = 'degrees']">
@@ -884,6 +886,44 @@
             </xsl:element>
         </xsl:if>
     </xsl:template>
+    <!-- =================================================================================== -->
+    <xsl:template match="eas:polygon[@eas:scheme = 'degrees']/eas:polygon-exterior">
+        <xsl:element name="geoLocation">
+            <xsl:element name="geoLocationPolygon">
+                <xsl:for-each select="eas:polygon-point">
+                    <xsl:element name="polygonPoint">
+                        <xsl:element name="pointLatitude"><xsl:value-of select="eas:x"/></xsl:element>
+                        <xsl:element name="pointLongitude"><xsl:value-of select="eas:y"/></xsl:element>
+                    </xsl:element>
+                </xsl:for-each>
+            </xsl:element>
+        </xsl:element>
+    </xsl:template>
+    <!-- =================================================================================== -->
+    <xsl:template match="eas:polygon[@eas:scheme = 'RD']/eas:polygon-exterior">
+        <!-- polygon in WGS84 -->
+        <xsl:element name="geoLocation">
+            <xsl:element name="geoLocationPolygon">
+                <xsl:for-each select="eas:polygon-point">
+                    <xsl:element name="polygonPoint">
+                        <xsl:element name="pointLatitude">
+                            <xsl:call-template name="rd-to-lat-long-lat">
+                                <xsl:with-param name="x" select="eas:x"/>
+                                <xsl:with-param name="y" select="eas:y"/>
+                            </xsl:call-template>
+                        </xsl:element>
+                        <xsl:element name="pointLongitude">
+                            <xsl:call-template name="rd-to-lat-long-lon">
+                                <xsl:with-param name="x" select="eas:x"/>
+                                <xsl:with-param name="y" select="eas:y"/>
+                            </xsl:call-template>
+                        </xsl:element>
+                    </xsl:element>
+                </xsl:for-each>
+            </xsl:element>
+        </xsl:element>
+    </xsl:template>
+    <!-- =================================================================================== -->
     <!-- ==================================================== -->
     <!-- x y to datacite pointLatitude pointLongitude -->
     <!-- ==================================================== -->

--- a/src/test/resources/maxi-emd.xml
+++ b/src/test/resources/maxi-emd.xml
@@ -178,20 +178,146 @@ Vestibulum mollis auctor sapien. Integer pede. Vivamus eu augue. Donec nisi puru
         <dcterms:temporal xml:lang="nld-NLD" eas:scheme="BSS0">temporal 0</dcterms:temporal>
         <dcterms:temporal xml:lang="nld-NLD" eas:scheme="BSS1">temporal 1</dcterms:temporal>
         <eas:spatial>
-            <eas:place xml:lang="nld-NLD" eas:scheme="BSS0">spatial 0</eas:place>
-            <eas:point eas:scheme="POI0">
+            <eas:place xml:lang="nld-NLD" eas:scheme="BSS0">spatial 2</eas:place>
+            <eas:point eas:scheme="RD">
                 <eas:x>123.45</eas:x>
                 <eas:y>456.78</eas:y>
             </eas:point>
         </eas:spatial>
         <eas:spatial>
-            <eas:place xml:lang="nld-NLD" eas:scheme="BSS1">spatial 1</eas:place>
-            <eas:box eas:scheme="BOX1">
+            <eas:place xml:lang="nld-NLD" eas:scheme="BSS1">spatial 3</eas:place>
+            <eas:box eas:scheme="RD">
                 <eas:north>12.3</eas:north>
                 <eas:east>23.4</eas:east>
                 <eas:south>34.5</eas:south>
                 <eas:west>45.6</eas:west>
             </eas:box>
+        </eas:spatial>
+        <!-- polygon with degrees -->
+        <eas:spatial>
+            <eas:place>A triangle between DANS, NWO and the railway station</eas:place>
+            <eas:polygon eas:scheme="degrees">
+                <eas:polygon-exterior>
+                    <eas:place>main triangle</eas:place>
+                    <eas:polygon-point>
+                        <eas:x>52.08110</eas:x>
+                        <eas:y>4.34521</eas:y>
+                    </eas:polygon-point>
+                    <eas:polygon-point>
+                        <eas:x>52.08071</eas:x>
+                        <eas:y>4.34422</eas:y>
+                    </eas:polygon-point>
+                    <eas:polygon-point>
+                        <eas:x>52.07913</eas:x>
+                        <eas:y>4.34332</eas:y>
+                    </eas:polygon-point>
+                    <eas:polygon-point>
+                        <eas:x>52.08110</eas:x>
+                        <eas:y>4.34521</eas:y>
+                    </eas:polygon-point>
+                </eas:polygon-exterior>
+                <eas:polygon-interior>
+                    <eas:place>hole1</eas:place>
+                    <eas:polygon-point>
+                        <eas:x>52.080542</eas:x>
+                        <eas:y>4.344215</eas:y>
+                    </eas:polygon-point>
+                    <eas:polygon-point>
+                        <eas:x>52.080450</eas:x>
+                        <eas:y>4.344323</eas:y>
+                    </eas:polygon-point>
+                    <eas:polygon-point>
+                        <eas:x>52.080357</eas:x>
+                        <eas:y>4.344110</eas:y>
+                    </eas:polygon-point>
+                    <eas:polygon-point>
+                        <eas:x>52.080542</eas:x>
+                        <eas:y>4.344215</eas:y>
+                    </eas:polygon-point>
+                </eas:polygon-interior>
+                <eas:polygon-interior>
+                    <eas:place>hole2</eas:place>
+                    <eas:polygon-point>
+                        <eas:x>52.080542</eas:x>
+                        <eas:y>4.344215</eas:y>
+                    </eas:polygon-point>
+                    <eas:polygon-point>
+                        <eas:x>52.080450</eas:x>
+                        <eas:y>4.344323</eas:y>
+                    </eas:polygon-point>
+                    <eas:polygon-point>
+                        <eas:x>52.080357</eas:x>
+                        <eas:y>4.344110</eas:y>
+                    </eas:polygon-point>
+                    <eas:polygon-point>
+                        <eas:x>52.080542</eas:x>
+                        <eas:y>4.344215</eas:y>
+                    </eas:polygon-point>
+                </eas:polygon-interior>
+            </eas:polygon>
+        </eas:spatial>
+        <!-- polygon with RD -->
+        <eas:spatial>
+            <eas:place>A triangle between DANS, NWO and the railway station</eas:place>
+            <eas:polygon eas:scheme="RD">
+                <eas:polygon-exterior>
+                    <eas:place>main triangle</eas:place>
+                    <eas:polygon-point>
+                        <eas:x>83575</eas:x>
+                        <eas:y>455271</eas:y>
+                    </eas:polygon-point>
+                    <eas:polygon-point>
+                        <eas:x>83507</eas:x>
+                        <eas:y>455229</eas:y>
+                    </eas:polygon-point>
+                    <eas:polygon-point>
+                        <eas:x>83443</eas:x>
+                        <eas:y>455054</eas:y>
+                    </eas:polygon-point>
+                    <eas:polygon-point>
+                        <eas:x>83575</eas:x>
+                        <eas:y>455271</eas:y>
+                    </eas:polygon-point>
+                </eas:polygon-exterior>
+                <eas:polygon-interior>
+                    <eas:place>hole1</eas:place>
+                    <eas:polygon-point>
+                        <eas:x>83506</eas:x>
+                        <eas:y>455210</eas:y>
+                    </eas:polygon-point>
+                    <eas:polygon-point>
+                        <eas:x>83513</eas:x>
+                        <eas:y>455200</eas:y>
+                    </eas:polygon-point>
+                    <eas:polygon-point>
+                        <eas:x>83499</eas:x>
+                        <eas:y>455189</eas:y>
+                    </eas:polygon-point>
+                    <eas:polygon-point>
+                        <eas:x>83506</eas:x>
+                        <eas:y>455210</eas:y>
+                    </eas:polygon-point>
+                </eas:polygon-interior>
+                <eas:polygon-interior>
+                    <eas:place>hole2</eas:place>
+                    <eas:polygon-point>
+                        <eas:x>83506</eas:x>
+                        <eas:y>455210</eas:y>
+                    </eas:polygon-point>
+                    <eas:polygon-point>
+                        <eas:x>83513</eas:x>
+                        <eas:y>455200</eas:y>
+                    </eas:polygon-point>
+                    <eas:polygon-point>
+                        <eas:x>83499</eas:x>
+                        <eas:y>455189</eas:y>
+                    </eas:polygon-point>
+                    <eas:polygon-point>
+                        <eas:x>83506</eas:x>
+                        <eas:y>455210</eas:y>
+                    </eas:polygon-point>
+                </eas:polygon-interior>
+            </eas:polygon>
         </eas:spatial>
     </emd:coverage>
     <emd:rights>


### PR DESCRIPTION
fixes EASY-1339

#### When applied it will
* add polygon support to the EMD-to-DataCite xsl
* add a polygon for both WGS84 and RD to one of the examples
* fix a couple of scheme references that weren't correct

@DANS-KNAW/easy for review