### PR TITLE
EASY-1365: license in DataCite output

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <inceptionYear>2014</inceptionYear>
 
     <properties>
-        <easy.emd.version>3.6</easy.emd.version>
+        <easy.emd.version>3.7.1</easy.emd.version>
     </properties>
 
     <scm>

--- a/src/main/resources/xslt-files/EMD_doi_datacite_v4.xsl
+++ b/src/main/resources/xslt-files/EMD_doi_datacite_v4.xsl
@@ -99,8 +99,7 @@
 
         <!-- 16. rights -->
         <xsl:element name="rightsList">
-            <xsl:apply-templates select="emd:rights/dcterms:accessRights" />
-            <xsl:apply-templates select="emd:rights/dcterms:license"/>
+            <xsl:apply-templates select="emd:rights"/>
         </xsl:element>
 
         <!-- 17. description -->
@@ -688,7 +687,38 @@
     <!-- ==================================================== -->
     <!-- emd:rights/dct:accessRights to datacite rights -->
     <!-- ==================================================== -->
-    <xsl:template match="emd:rights/dcterms:accessRights">
+    <xsl:template match="emd:rights">
+        <xsl:apply-templates select="dcterms:accessRights"/>
+
+        <xsl:variable name="licenses" select="dcterms:license"/>
+        <xsl:if test="$licenses">
+            <xsl:for-each select="$licenses">
+                <xsl:choose>
+                    <xsl:when test=". = 'accept' and ../dcterms:accessRights = 'OPEN_ACCESS'">
+                        <xsl:variable name="cc0" select="'http://creativecommons.org/publicdomain/zero/1.0'"/>
+                        <xsl:element name="rights">
+                            <xsl:attribute name="rightsURI" select="$cc0"/>
+                            <xsl:value-of select="concat('License: ', $cc0)"/>
+                        </xsl:element>
+                    </xsl:when>
+                    <xsl:when test=". = 'accept'"/> <!-- this case is such that the 'accept' value does not end up in the otherwise clause -->
+                    <xsl:when test="starts-with(., 'http://') or starts-with(., 'https://')">
+                        <xsl:element name="rights">
+                            <xsl:attribute name="rightsURI" select="."/>
+                            <xsl:value-of select="concat('License: ', .)"/>
+                        </xsl:element>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:element name="rights">
+                            <xsl:value-of select="concat('License: ', .)"/>
+                        </xsl:element>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:for-each>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template match="dcterms:accessRights">
         <!-- 
          info:eu-repo/semantics/closedAccess
          info:eu-repo/semantics/embargoedAccess
@@ -717,17 +747,6 @@
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:element>
-    </xsl:template>
-
-    <xsl:template match="emd:rights/dcterms:license">
-        <xsl:if test=". != 'accept'">
-            <xsl:element name="rights">
-                <xsl:if test="starts-with(., 'http://') or starts-with(., 'https://')">
-                    <xsl:attribute name="rightsURI" select="."/>
-                </xsl:if>
-                <xsl:value-of select="concat('License: ', .)"/>
-            </xsl:element>
-        </xsl:if>
     </xsl:template>
 
     <!-- ==================================================== -->

--- a/src/main/resources/xslt-files/EMD_doi_datacite_v4.xsl
+++ b/src/main/resources/xslt-files/EMD_doi_datacite_v4.xsl
@@ -720,7 +720,14 @@
     </xsl:template>
 
     <xsl:template match="emd:rights/dcterms:license">
-        <xsl:element name="rights"><xsl:value-of select="."/></xsl:element>
+        <xsl:if test=". != 'accept'">
+            <xsl:element name="rights">
+                <xsl:if test="starts-with(., 'http://') or starts-with(., 'https://')">
+                    <xsl:attribute name="rightsURI" select="."/>
+                </xsl:if>
+                <xsl:value-of select="concat('License: ', .)"/>
+            </xsl:element>
+        </xsl:if>
     </xsl:template>
 
     <!-- ==================================================== -->

--- a/src/main/resources/xslt-files/EMD_doi_datacite_v4.xsl
+++ b/src/main/resources/xslt-files/EMD_doi_datacite_v4.xsl
@@ -100,6 +100,7 @@
         <!-- 16. rights -->
         <xsl:element name="rightsList">
             <xsl:apply-templates select="emd:rights/dcterms:accessRights" />
+            <xsl:apply-templates select="emd:rights/dcterms:license"/>
         </xsl:element>
 
         <!-- 17. description -->
@@ -438,7 +439,7 @@
     </xsl:template>
 
     <!-- ==================================================== -->
-    <!-- emd:audience, emd:subject, emd:coverage => subject 
+    <!-- emd:audience, emd:subject, emd:coverage => subject
            - there are special subjects for archaeology datasets
              in a scheme 'archaeology.dc.subject' -->
     <!-- ==================================================== -->
@@ -716,6 +717,10 @@
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:element>
+    </xsl:template>
+
+    <xsl:template match="emd:rights/dcterms:license">
+        <xsl:element name="rights"><xsl:value-of select="."/></xsl:element>
     </xsl:template>
 
     <!-- ==================================================== -->


### PR DESCRIPTION
fixes EASY-1365

#### When applied it will
* add the license(s) in the EMD to the DataCite output
    * [x] if the content is `accept`, the license will be ignored
    * [x] if the content is a URL (e.g. starts with either `http://` or `https://`), the content is also added to the `rightsURI` attribute. Potential flaws with this would be a content that starts with `http(s)://` but then continues with something that is not a URL (like `http:// hello world, how are you?`). I'm not sure though how to test in XSLT that the whole content represents ONLY a URL. If you got any solutions, please let me know!
    * [x] if the content is `accept` and the access category is `OPEN_ACCESS`, we will provide the CC0 license url

@DANS-KNAW/easy for review
@lindareijnhoudt can you check whether you're OK with this?