### PR TITLE
EASY-1475: Put other_access_doi in alternateIdentifier

### DIFF
--- a/src/main/resources/xslt-files/EMD_doi_datacite_v4.xsl
+++ b/src/main/resources/xslt-files/EMD_doi_datacite_v4.xsl
@@ -763,9 +763,17 @@
         <xsl:element name="alternateIdentifiers">
             <!-- we cannot tell whether identifiers other than the ones matched below
                  belong to the dataset, so we leave them out (EASY-1002) -->
+            <xsl:apply-templates select="dc:identifier[@eas:scheme='DOI_OTHER_ACCESS']" />
             <xsl:apply-templates select="dc:identifier[@eas:scheme='PID']" />
             <xsl:apply-templates select="dc:identifier[@eas:scheme='DMO_ID']" />
             <xsl:apply-templates select="dc:identifier[@eas:scheme='AIP_ID']" />
+        </xsl:element>
+    </xsl:template>
+
+    <xsl:template match="dc:identifier[@eas:scheme='DOI_OTHER_ACCESS']">
+        <xsl:element name="alternateIdentifier">
+            <xsl:attribute name="alternateIdentifierType" select="'DOI'"/>
+            <xsl:value-of select="."/>
         </xsl:element>
     </xsl:template>
 

--- a/src/test/java/nl/knaw/dans/easy/DataciteResourcesBuilderTest.java
+++ b/src/test/java/nl/knaw/dans/easy/DataciteResourcesBuilderTest.java
@@ -244,6 +244,17 @@ public class DataciteResourcesBuilderTest {
     }
 
     @Test
+    public void otherAccessDoi() throws Exception {
+        ignoreIfNot("kernel-" + version);
+
+        String periodXPath = "//*[local-name()='alternateIdentifier'][@alternateIdentifierType='DOI']";
+        Element identifierElement = (Element) xPath.evaluate(periodXPath, docElement, XPathConstants.NODE);
+
+        assertEquals(identifierElement.getTextContent(), "10.5072/other-test-123");
+        assertEquals(identifierElement.getAttribute("alternateIdentifierType"), "DOI");
+    }
+
+    @Test
     public void validateXmlOutputAgainstDataciteSchema() throws Exception {
         ignoreIfNot("kernel-" + version);
         ignoreIfSchemaNotAccessible();

--- a/src/test/resources/emd.xml
+++ b/src/test/resources/emd.xml
@@ -53,6 +53,7 @@
         <dc:identifier eas:scheme="PID" eas:identification-system="http://www.persistent-identifier.nl">urn:nbn:nl:ui:13-sba-6zn</dc:identifier>
         <dc:identifier eas:scheme="DMO_ID">easy-dataset:1</dc:identifier>
         <dc:identifier eas:scheme="DOI" eas:identification-system="https://doi.org">10.5072/dans-test-123</dc:identifier>
+        <dc:identifier eas:scheme="DOI_OTHER_ACCESS" eas:identification-system="https://doi.org">10.5072/other-test-123</dc:identifier>
     </emd:identifier>
     <emd:source/>
     <emd:language>


### PR DESCRIPTION
fixes EASY-1475

#### When applied it will
* Put other_access_doi in alternateIdentifier
* Add test

#### Where should the reviewer @DANS-KNAW/easy start?

