### PR TITLE
EASY-1816: add check to see if the doi is registered with datacite

### DIFF
--- a/src/main/java/nl/knaw/dans/easy/DataciteService.java
+++ b/src/main/java/nl/knaw/dans/easy/DataciteService.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2014 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,7 +25,6 @@ import nl.knaw.dans.easy.DataciteResourcesBuilder.Resources;
 import nl.knaw.dans.pf.language.emd.EasyMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 
 public class DataciteService {
 
@@ -74,9 +73,7 @@ public class DataciteService {
     private String postDoi(String content) throws DataciteServiceException {
         try {
             logger.debug("THIS IS SENT TO DATACITE: {}", content);
-            ClientResponse response = createDoiWebResource()
-                .type(configuration.getDoiRegistrationContentType())
-                .post(ClientResponse.class, content);
+            ClientResponse response = createDoiWebResource().type(configuration.getDoiRegistrationContentType()).post(ClientResponse.class, content);
             String entity = response.getEntity(String.class);
             if (response.getStatus() != CREATED)
                 throw createDoiPostFailedException(response.getStatus(), entity);
@@ -92,34 +89,29 @@ public class DataciteService {
 
     public boolean getDoi(String doi) throws DataciteServiceException {
         try {
-          final String uri = configuration.getDoiRegistrationUri() + "/" + doi;
-          logger.debug("Checking if doi: {} is registered in Datacite", doi);
-          final ClientResponse response = createWebResource(uri)
-              .type(configuration.getMetadataRegistrationContentType()).get(ClientResponse.class);
-          int status = response.getStatus();
-          if (status == NO_CONTENT || status == OK) {
-            return true;
-          }
-          else if (status == NOT_FOUND) {
-            return false;
-          }
-          else
-            throw createDoiGetFailedException(status, response.getEntity(String.class));
+            final String uri = configuration.getDoiRegistrationUri() + "/" + doi;
+            logger.debug("Checking if doi: {} is registered in Datacite", doi);
+            final ClientResponse response = createWebResource(uri).type(configuration.getMetadataRegistrationContentType()).get(ClientResponse.class);
+            int status = response.getStatus();
+            if (status == NO_CONTENT || status == OK) {
+                return true;
+            } else if (status == NOT_FOUND) {
+                return false;
+            } else
+                throw createDoiGetFailedException(status, response.getEntity(String.class));
         }
         catch (UniformInterfaceException e) {
-          throw createDoiGetFailedException(e);
+            throw createDoiGetFailedException(e);
         }
         catch (DataciteServiceException e) {
-          throw createDoiGetFailedException(e);
+            throw createDoiGetFailedException(e);
         }
     }
 
     private String postMetadata(String content) throws DataciteServiceException {
         try {
             logger.debug("THIS IS SENT TO DATACITE: {}", content);
-            ClientResponse response = createMetadataWebResource()
-                .type(configuration.getMetadataRegistrationContentType())
-                .post(ClientResponse.class, content);
+            ClientResponse response = createMetadataWebResource().type(configuration.getMetadataRegistrationContentType()).post(ClientResponse.class, content);
             String entity = response.getEntity(String.class);
             if (response.getStatus() != CREATED)
                 throw createMetadataPostFailedException(response.getStatus(), entity);
@@ -148,15 +140,15 @@ public class DataciteService {
     }
 
     private DataciteServiceException createDoiGetFailedException(int status, String cause) {
-      return new DataciteServiceException("GET doi failed: HTTP error code " + status + " and cause: " + cause);
+        return new DataciteServiceException("GET doi failed: HTTP error code " + status + " and cause: " + cause);
     }
 
     private DataciteServiceException createDoiGetFailedException(Exception cause) {
-      return createGetFailedException("DOI", cause);
+        return createGetFailedException("DOI", cause);
     }
 
     private DataciteServiceException createGetFailedException(String kind, Exception cause) {
-      return new DataciteServiceException(kind + " get failed: " + cause.getMessage(), cause);
+        return new DataciteServiceException(kind + " get failed: " + cause.getMessage(), cause);
     }
 
     private DataciteServiceException createDoiPostFailedException(int status, String cause) {

--- a/src/main/java/nl/knaw/dans/easy/DataciteService.java
+++ b/src/main/java/nl/knaw/dans/easy/DataciteService.java
@@ -86,9 +86,9 @@ public class DataciteService {
         }
     }
 
-    public boolean getDoi(String doi) throws DataciteServiceException { // is doi registered?
+    public boolean getDoi(String doi) throws DataciteServiceException {
         try {
-          final String uri = String.format("{}/{}", configuration.getDoiRegistrationUri(), doi);
+          final String uri = configuration.getDoiRegistrationUri() + "/" + doi;
           logger.debug("Checking if doi: {} is registered in Datacite", doi);
           final ClientResponse response = createWebResource(uri)
               .type(configuration.getMetadataRegistrationContentType()).get(ClientResponse.class);

--- a/src/main/java/nl/knaw/dans/easy/DataciteService.java
+++ b/src/main/java/nl/knaw/dans/easy/DataciteService.java
@@ -87,7 +87,7 @@ public class DataciteService {
         }
     }
 
-    public boolean getDoi(String doi) throws DataciteServiceException {
+    public boolean doiExists(String doi) throws DataciteServiceException {
         try {
             String uri = configuration.getDoiRegistrationUri() + "/" + doi;
             logger.debug("Checking if doi: {} is registered in Datacite", doi);

--- a/src/main/java/nl/knaw/dans/easy/DataciteService.java
+++ b/src/main/java/nl/knaw/dans/easy/DataciteService.java
@@ -31,10 +31,10 @@ public class DataciteService {
     private static Logger logger = LoggerFactory.getLogger(DataciteService.class);
 
     private final DataciteServiceConfiguration configuration;
-    private final int OK = 200;
-    private final int CREATED = 201;
-    private final int NO_CONTENT = 204;
-    private final int NOT_FOUND = 404;
+    private static final int OK = 200;
+    private static final int CREATED = 201;
+    private static final int NO_CONTENT = 204;
+    private static final int NOT_FOUND = 404;
     private DataciteResourcesBuilder resourcesBuilder;
 
     public DataciteService(DataciteServiceConfiguration configuration) {
@@ -73,9 +73,7 @@ public class DataciteService {
     private String postDoi(String content) throws DataciteServiceException {
         try {
             logger.debug("THIS IS SENT TO DATACITE: {}", content);
-            ClientResponse response = createDoiWebResource()
-                .type(configuration.getDoiRegistrationContentType())
-                .post(ClientResponse.class, content);
+            ClientResponse response = createDoiWebResource().type(configuration.getDoiRegistrationContentType()).post(ClientResponse.class, content);
             String entity = response.getEntity(String.class);
             if (response.getStatus() != CREATED)
                 throw createDoiPostFailedException(response.getStatus(), entity);
@@ -91,11 +89,9 @@ public class DataciteService {
 
     public boolean getDoi(String doi) throws DataciteServiceException {
         try {
-            final String uri = configuration.getDoiRegistrationUri() + "/" + doi;
+            String uri = configuration.getDoiRegistrationUri() + "/" + doi;
             logger.debug("Checking if doi: {} is registered in Datacite", doi);
-            final ClientResponse response = createWebResource(uri)
-                .type(configuration.getMetadataRegistrationContentType())
-                .get(ClientResponse.class);
+            ClientResponse response = createWebResource(uri).type(configuration.getMetadataRegistrationContentType()).get(ClientResponse.class);
             int status = response.getStatus();
             if (status == NO_CONTENT || status == OK) {
                 return true;
@@ -115,9 +111,7 @@ public class DataciteService {
     private String postMetadata(String content) throws DataciteServiceException {
         try {
             logger.debug("THIS IS SENT TO DATACITE: {}", content);
-            ClientResponse response = createMetadataWebResource()
-                .type(configuration.getMetadataRegistrationContentType())
-                .post(ClientResponse.class, content);
+            ClientResponse response = createMetadataWebResource().type(configuration.getMetadataRegistrationContentType()).post(ClientResponse.class, content);
             String entity = response.getEntity(String.class);
             if (response.getStatus() != CREATED)
                 throw createMetadataPostFailedException(response.getStatus(), entity);
@@ -150,11 +144,7 @@ public class DataciteService {
     }
 
     private DataciteServiceException createDoiGetFailedException(Exception cause) {
-        return createGetFailedException("DOI", cause);
-    }
-
-    private DataciteServiceException createGetFailedException(String kind, Exception cause) {
-        return new DataciteServiceException(kind + " get failed: " + cause.getMessage(), cause);
+        return new DataciteServiceException("DOI get failed: " + cause.getMessage(), cause);
     }
 
     private DataciteServiceException createDoiPostFailedException(int status, String cause) {

--- a/src/main/java/nl/knaw/dans/easy/DataciteService.java
+++ b/src/main/java/nl/knaw/dans/easy/DataciteService.java
@@ -26,15 +26,16 @@ import nl.knaw.dans.pf.language.emd.EasyMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static javax.ws.rs.core.Response.Status.CREATED;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.NO_CONTENT;
+import static javax.ws.rs.core.Response.Status.OK;
+
 public class DataciteService {
 
     private static Logger logger = LoggerFactory.getLogger(DataciteService.class);
 
     private final DataciteServiceConfiguration configuration;
-    private static final int OK = 200;
-    private static final int CREATED = 201;
-    private static final int NO_CONTENT = 204;
-    private static final int NOT_FOUND = 404;
     private DataciteResourcesBuilder resourcesBuilder;
 
     public DataciteService(DataciteServiceConfiguration configuration) {
@@ -75,7 +76,7 @@ public class DataciteService {
             logger.debug("THIS IS SENT TO DATACITE: {}", content);
             ClientResponse response = createDoiWebResource().type(configuration.getDoiRegistrationContentType()).post(ClientResponse.class, content);
             String entity = response.getEntity(String.class);
-            if (response.getStatus() != CREATED)
+            if (response.getStatus() != CREATED.getStatusCode())
                 throw createDoiPostFailedException(response.getStatus(), entity);
             return entity;
         }
@@ -93,9 +94,9 @@ public class DataciteService {
             logger.debug("Checking if doi: {} is registered in Datacite", doi);
             ClientResponse response = createWebResource(uri).type(configuration.getMetadataRegistrationContentType()).get(ClientResponse.class);
             int status = response.getStatus();
-            if (status == NO_CONTENT || status == OK) {
+            if (status == NO_CONTENT.getStatusCode() || status == OK.getStatusCode()) {
                 return true;
-            } else if (status == NOT_FOUND) {
+            } else if (status == NOT_FOUND.getStatusCode()) {
                 return false;
             } else
                 throw createDoiGetFailedException(status, response.getEntity(String.class));
@@ -113,7 +114,7 @@ public class DataciteService {
             logger.debug("THIS IS SENT TO DATACITE: {}", content);
             ClientResponse response = createMetadataWebResource().type(configuration.getMetadataRegistrationContentType()).post(ClientResponse.class, content);
             String entity = response.getEntity(String.class);
-            if (response.getStatus() != CREATED)
+            if (response.getStatus() != CREATED.getStatusCode())
                 throw createMetadataPostFailedException(response.getStatus(), entity);
             return entity;
         }

--- a/src/main/java/nl/knaw/dans/easy/DataciteService.java
+++ b/src/main/java/nl/knaw/dans/easy/DataciteService.java
@@ -73,7 +73,9 @@ public class DataciteService {
     private String postDoi(String content) throws DataciteServiceException {
         try {
             logger.debug("THIS IS SENT TO DATACITE: {}", content);
-            ClientResponse response = createDoiWebResource().type(configuration.getDoiRegistrationContentType()).post(ClientResponse.class, content);
+            ClientResponse response = createDoiWebResource()
+                .type(configuration.getDoiRegistrationContentType())
+                .post(ClientResponse.class, content);
             String entity = response.getEntity(String.class);
             if (response.getStatus() != CREATED)
                 throw createDoiPostFailedException(response.getStatus(), entity);
@@ -89,20 +91,18 @@ public class DataciteService {
 
     public boolean getDoi(String doi) throws DataciteServiceException {
         try {
-          final String uri = configuration.getDoiRegistrationUri() + "/" + doi;
-          logger.debug("Checking if doi: {} is registered in Datacite", doi);
-          final ClientResponse response = createWebResource(uri)
-              .type(configuration.getMetadataRegistrationContentType())
-              .get(ClientResponse.class);
-          int status = response.getStatus();
-          if (status == NO_CONTENT || status == OK) {
-            return true;
-          }
-          else if (status == NOT_FOUND) {
-            return false;
-          }
-          else
-            throw createDoiGetFailedException(status, response.getEntity(String.class));
+            final String uri = configuration.getDoiRegistrationUri() + "/" + doi;
+            logger.debug("Checking if doi: {} is registered in Datacite", doi);
+            final ClientResponse response = createWebResource(uri)
+                .type(configuration.getMetadataRegistrationContentType())
+                .get(ClientResponse.class);
+            int status = response.getStatus();
+            if (status == NO_CONTENT || status == OK) {
+                return true;
+            } else if (status == NOT_FOUND) {
+                return false;
+            } else
+                throw createDoiGetFailedException(status, response.getEntity(String.class));
         }
         catch (UniformInterfaceException e) {
             throw createDoiGetFailedException(e);
@@ -115,7 +115,9 @@ public class DataciteService {
     private String postMetadata(String content) throws DataciteServiceException {
         try {
             logger.debug("THIS IS SENT TO DATACITE: {}", content);
-            ClientResponse response = createMetadataWebResource().type(configuration.getMetadataRegistrationContentType()).post(ClientResponse.class, content);
+            ClientResponse response = createMetadataWebResource()
+                .type(configuration.getMetadataRegistrationContentType())
+                .post(ClientResponse.class, content);
             String entity = response.getEntity(String.class);
             if (response.getStatus() != CREATED)
                 throw createMetadataPostFailedException(response.getStatus(), entity);

--- a/src/main/java/nl/knaw/dans/easy/DataciteService.java
+++ b/src/main/java/nl/knaw/dans/easy/DataciteService.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2014 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,11 +15,6 @@
  */
 package nl.knaw.dans.easy;
 
-import javax.ws.rs.core.Response;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.sun.jersey.api.client.Client;
 import com.sun.jersey.api.client.ClientHandlerException;
 import com.sun.jersey.api.client.ClientResponse;
@@ -27,8 +22,11 @@ import com.sun.jersey.api.client.UniformInterfaceException;
 import com.sun.jersey.api.client.WebResource;
 import com.sun.jersey.api.client.filter.HTTPBasicAuthFilter;
 import nl.knaw.dans.easy.DataciteResourcesBuilder.Resources;
-
 import nl.knaw.dans.pf.language.emd.EasyMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.Response;
 
 public class DataciteService {
 
@@ -88,10 +86,36 @@ public class DataciteService {
         }
     }
 
+    public boolean getDoi(String doi) throws DataciteServiceException { // is doi registered?
+        try {
+          final String uri = String.format("{}/{}", configuration.getDoiRegistrationUri(), doi);
+          logger.debug("Checking if doi: {} is registered in Datacite", doi);
+          final ClientResponse response = createWebResource(uri)
+              .type(configuration.getMetadataRegistrationContentType()).get(ClientResponse.class);
+          int status = response.getStatus();
+          if (status == Response.Status.NO_CONTENT.getStatusCode()) {
+            return true;
+          }
+          else if (status == Response.Status.NOT_FOUND.getStatusCode()) {
+            return false;
+          }
+          else
+            throw createDoiGetFailedException(status, response.getEntity(String.class));
+        }
+        catch (UniformInterfaceException e) {
+          throw createDoiGetFailedException(e);
+        }
+        catch (DataciteServiceException e) {
+          throw createDoiGetFailedException(e);
+        }
+    }
+
     private String postMetadata(String content) throws DataciteServiceException {
         try {
             logger.debug("THIS IS SENT TO DATACITE: {}", content);
-            ClientResponse response = createMetadataWebResource().type(configuration.getMetadataRegistrationContentType()).post(ClientResponse.class, content);
+            ClientResponse response = createMetadataWebResource()
+                .type(configuration.getMetadataRegistrationContentType())
+                .post(ClientResponse.class, content);
             String entity = response.getEntity(String.class);
             if (response.getStatus() != Response.Status.CREATED.getStatusCode())
                 throw createMetadataPostFailedException(response.getStatus(), entity);
@@ -117,6 +141,18 @@ public class DataciteService {
         Client client = Client.create();
         client.addFilter(new HTTPBasicAuthFilter(configuration.getUsername(), configuration.getPassword()));
         return client.resource(uri);
+    }
+
+    private DataciteServiceException createDoiGetFailedException(int status, String cause) {
+      return new DataciteServiceException("GET doi failed: HTTP error code " + status + " and cause: " + cause);
+    }
+
+    private DataciteServiceException createDoiGetFailedException(Exception cause) {
+      return createGetFailedException("DOI", cause);
+    }
+
+    private DataciteServiceException createGetFailedException(String kind, Exception cause) {
+      return new DataciteServiceException(kind + " get failed: " + cause.getMessage(), cause);
     }
 
     private DataciteServiceException createDoiPostFailedException(int status, String cause) {

--- a/src/main/java/nl/knaw/dans/easy/DataciteService.java
+++ b/src/main/java/nl/knaw/dans/easy/DataciteService.java
@@ -26,14 +26,16 @@ import nl.knaw.dans.pf.language.emd.EasyMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.core.Response;
 
 public class DataciteService {
 
     private static Logger logger = LoggerFactory.getLogger(DataciteService.class);
 
     private final DataciteServiceConfiguration configuration;
-
+    private final int OK = 200;
+    private final int CREATED = 201;
+    private final int NO_CONTENT = 204;
+    private final int NOT_FOUND = 404;
     private DataciteResourcesBuilder resourcesBuilder;
 
     public DataciteService(DataciteServiceConfiguration configuration) {
@@ -72,9 +74,11 @@ public class DataciteService {
     private String postDoi(String content) throws DataciteServiceException {
         try {
             logger.debug("THIS IS SENT TO DATACITE: {}", content);
-            ClientResponse response = createDoiWebResource().type(configuration.getDoiRegistrationContentType()).post(ClientResponse.class, content);
+            ClientResponse response = createDoiWebResource()
+                .type(configuration.getDoiRegistrationContentType())
+                .post(ClientResponse.class, content);
             String entity = response.getEntity(String.class);
-            if (response.getStatus() != Response.Status.CREATED.getStatusCode())
+            if (response.getStatus() != CREATED)
                 throw createDoiPostFailedException(response.getStatus(), entity);
             return entity;
         }
@@ -93,10 +97,10 @@ public class DataciteService {
           final ClientResponse response = createWebResource(uri)
               .type(configuration.getMetadataRegistrationContentType()).get(ClientResponse.class);
           int status = response.getStatus();
-          if (status == Response.Status.NO_CONTENT.getStatusCode()) {
+          if (status == NO_CONTENT || status == OK) {
             return true;
           }
-          else if (status == Response.Status.NOT_FOUND.getStatusCode()) {
+          else if (status == NOT_FOUND) {
             return false;
           }
           else
@@ -117,7 +121,7 @@ public class DataciteService {
                 .type(configuration.getMetadataRegistrationContentType())
                 .post(ClientResponse.class, content);
             String entity = response.getEntity(String.class);
-            if (response.getStatus() != Response.Status.CREATED.getStatusCode())
+            if (response.getStatus() != CREATED)
                 throw createMetadataPostFailedException(response.getStatus(), entity);
             return entity;
         }


### PR DESCRIPTION
fixes EASY-1816

- [x] test if the client works
- [x] discuss whether to return a boolean, or  a response entity

#### When applied it will
* be able to check if a doi is allready registered with Datacite

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?
* build the project (online tests are ignored when the credentials for DataCite are not specified)

  ```mvn clean install -Ddatacite.user=... -Ddatacite.password=...```

#### related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ---
easy-ingest-flow                   | EASY-1762     | 
