### PR TITLE
Easy 1762 make timeouts for datacite calls configurable

### DIFF
--- a/src/main/java/nl/knaw/dans/easy/DataciteService.java
+++ b/src/main/java/nl/knaw/dans/easy/DataciteService.java
@@ -115,6 +115,8 @@ public class DataciteService {
 
     private WebResource createWebResource(String uri) {
         Client client = Client.create();
+        client.setConnectTimeout(configuration.getWebResourceConnectionTimeout());
+        client.setReadTimeout(configuration.getWebResourceReadTimeout());
         client.addFilter(new HTTPBasicAuthFilter(configuration.getUsername(), configuration.getPassword()));
         return client.resource(uri);
     }

--- a/src/main/java/nl/knaw/dans/easy/DataciteService.java
+++ b/src/main/java/nl/knaw/dans/easy/DataciteService.java
@@ -136,8 +136,8 @@ public class DataciteService {
 
     private WebResource createWebResource(String uri) {
         Client client = Client.create();
-        client.setConnectTimeout(configuration.getWebResourceConnectionTimeout());
-        client.setReadTimeout(configuration.getWebResourceReadTimeout());
+        client.setConnectTimeout(configuration.getConnectionTimeout());
+        client.setReadTimeout(configuration.getReadTimeout());
         client.addFilter(new HTTPBasicAuthFilter(configuration.getUsername(), configuration.getPassword()));
         return client.resource(uri);
     }

--- a/src/main/java/nl/knaw/dans/easy/DataciteServiceConfiguration.java
+++ b/src/main/java/nl/knaw/dans/easy/DataciteServiceConfiguration.java
@@ -28,8 +28,8 @@ public class DataciteServiceConfiguration {
     private static final String DEFAULT_DATACITE_DOI_CONTENT_TYPE = "text/plain;charset=UTF-8";
     private static final String DEFAULT_DATACITE_METADATA_URI = "https://mds.test.datacite.org/metadata";
     private static final String DEFAULT_DATACITE_METADATA_CONTENT_TYPE = "application/xml";
-    private static final int DEFAULT_WEB_RESOURCE_READ_TIMEOUT_IN_MILLIS = 5000;
-    private static final int DEFAULT_WEB_RESOURCE_CONNECTION_TIMEOUT_IN_MILLIS = 5000;
+    private static final int DEFAULT_READ_TIMEOUT_IN_MILLIS = 5000;
+    private static final int DEFAULT_CONNECTION_TIMEOUT_IN_MILLIS = 5000;
 
     private String username;
     private String password;
@@ -40,8 +40,8 @@ public class DataciteServiceConfiguration {
     private String xslVersion = DEFAULT_XSL_VERSION;
     private String xslEmd2datacite = DEFAULT_XSL;
     private URL datasetResolver;
-    private int webResourceReadTimeout = DEFAULT_WEB_RESOURCE_READ_TIMEOUT_IN_MILLIS;
-    private int WebResourceConnectionTimeout = DEFAULT_WEB_RESOURCE_CONNECTION_TIMEOUT_IN_MILLIS;
+    private int readTimeout = DEFAULT_READ_TIMEOUT_IN_MILLIS;
+    private int connectionTimeout = DEFAULT_CONNECTION_TIMEOUT_IN_MILLIS;
 
     public String getUsername() {
         if (StringUtils.isBlank(username))
@@ -138,19 +138,19 @@ public class DataciteServiceConfiguration {
         this.datasetResolver = datasetResolver;
     }
 
-    public int getWebResourceReadTimeout() {
-        return this.webResourceReadTimeout;
+    public int getReadTimeout() {
+        return this.readTimeout;
     }
 
-    public void setWebResourceReadTimeout(int webResourceReadTimeout) {
-        this.webResourceReadTimeout = webResourceReadTimeout;
+    public void setReadTimeout(int readTimeout) {
+        this.readTimeout = readTimeout;
     }
 
-    public int getWebResourceConnectionTimeout() {
-        return this.WebResourceConnectionTimeout;
+    public int getConnectionTimeout() {
+        return this.connectionTimeout;
     }
 
-    public void setWebResourceConnectionTimeout(int webResourceConnectionTimeout) {
-        this.WebResourceConnectionTimeout = webResourceConnectionTimeout;
+    public void setConnectionTimeout(int connectionTimeout) {
+        this.connectionTimeout = connectionTimeout;
     }
 }

--- a/src/main/java/nl/knaw/dans/easy/DataciteServiceConfiguration.java
+++ b/src/main/java/nl/knaw/dans/easy/DataciteServiceConfiguration.java
@@ -28,6 +28,8 @@ public class DataciteServiceConfiguration {
     private static final String DEFAULT_DATACITE_DOI_CONTENT_TYPE = "text/plain;charset=UTF-8";
     private static final String DEFAULT_DATACITE_METADATA_URI = "https://mds.test.datacite.org/metadata";
     private static final String DEFAULT_DATACITE_METADATA_CONTENT_TYPE = "application/xml";
+    private static final int DEFAULT_WEB_RESOURCE_READ_TIMEOUT_IN_MILLIS = 5000;
+    private static final int DEFAULT_WEB_RESOURCE_CONNECTION_TIMEOUT_IN_MILLIS = 5000;
 
     private String username;
     private String password;
@@ -38,6 +40,8 @@ public class DataciteServiceConfiguration {
     private String xslVersion = DEFAULT_XSL_VERSION;
     private String xslEmd2datacite = DEFAULT_XSL;
     private URL datasetResolver;
+    private int webResourceReadTimeout = DEFAULT_WEB_RESOURCE_READ_TIMEOUT_IN_MILLIS;
+    private int WebResourceConnectionTimeout = DEFAULT_WEB_RESOURCE_CONNECTION_TIMEOUT_IN_MILLIS;
 
     public String getUsername() {
         if (StringUtils.isBlank(username))
@@ -132,5 +136,21 @@ public class DataciteServiceConfiguration {
 
     public void setDatasetResolver(URL datasetResolver) {
         this.datasetResolver = datasetResolver;
+    }
+
+    public int getWebResourceReadTimeout() {
+        return this.webResourceReadTimeout;
+    }
+
+    public void setWebResourceReadTimeout(int webResourceReadTimeout) {
+        this.webResourceReadTimeout = webResourceReadTimeout;
+    }
+
+    public int getWebResourceConnectionTimeout() {
+        return this.WebResourceConnectionTimeout;
+    }
+
+    public void setWebResourceConnectionTimeout(int webResourceConnectionTimeout) {
+        this.WebResourceConnectionTimeout = webResourceConnectionTimeout;
     }
 }

--- a/src/test/java/nl/knaw/dans/easy/DataciteServiceTest.java
+++ b/src/test/java/nl/knaw/dans/easy/DataciteServiceTest.java
@@ -36,6 +36,7 @@ import java.net.URL;
 import java.util.Properties;
 import java.util.UUID;
 
+import com.sun.jersey.api.client.WebResource;
 import nl.knaw.dans.pf.language.emd.EasyMetadata;
 
 import org.apache.commons.io.FileUtils;

--- a/src/test/java/nl/knaw/dans/easy/DataciteServiceTest.java
+++ b/src/test/java/nl/knaw/dans/easy/DataciteServiceTest.java
@@ -15,6 +15,20 @@
  */
 package nl.knaw.dans.easy;
 
+import nl.knaw.dans.pf.language.emd.EasyMetadata;
+import org.apache.commons.io.FileUtils;
+import org.easymock.Capture;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+
+import java.io.File;
+import java.net.URL;
+import java.util.Properties;
+import java.util.UUID;
+
 import static org.easymock.EasyMock.capture;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -30,22 +44,6 @@ import static org.powermock.api.easymock.PowerMock.resetAll;
 import static org.powermock.api.easymock.PowerMock.verifyAll;
 import static org.powermock.reflect.Whitebox.getInternalState;
 import static org.powermock.reflect.Whitebox.setInternalState;
-
-import java.io.File;
-import java.net.URL;
-import java.util.Properties;
-import java.util.UUID;
-
-import com.sun.jersey.api.client.WebResource;
-import nl.knaw.dans.pf.language.emd.EasyMetadata;
-
-import org.apache.commons.io.FileUtils;
-import org.easymock.Capture;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.slf4j.Logger;
 
 public class DataciteServiceTest {
 


### PR DESCRIPTION
fixes EASY-Easy 1762

#### When applied it will
*  make the timeout for calls to datacite configurable

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?
* build the project (online tests are ignored when the credentials for DataCite are not specified)

  ```mvn clean install -Ddatacite.user=... -Ddatacite.password=...```

#### related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ---
easy-                      | [PR#](PRlink)     | 