### PR TITLE
Easy 1762 sub exceptions

### DIFF
--- a/src/main/java/nl/knaw/dans/easy/DataciteBadRequestException.java
+++ b/src/main/java/nl/knaw/dans/easy/DataciteBadRequestException.java
@@ -15,21 +15,9 @@
  */
 package nl.knaw.dans.easy;
 
-public class DataciteServiceException extends Exception {
-
-    private static final long serialVersionUID = 1L;
-    protected int httpStatusCode = 0;
-
-    public DataciteServiceException(String message, Exception cause) {
-        super(message, cause);
-    }
-
-    public DataciteServiceException(String message, int httpStatusCode) {
-        super(message);
+public class DataciteBadRequestException extends DataciteServiceException {
+    public DataciteBadRequestException(String message, int httpStatusCode) {
+        super(message, httpStatusCode);
         this.httpStatusCode = httpStatusCode;
-    }
-
-    public int getHttpStatusCode() {
-        return this.httpStatusCode;
     }
 }

--- a/src/main/java/nl/knaw/dans/easy/DataciteService.java
+++ b/src/main/java/nl/knaw/dans/easy/DataciteService.java
@@ -149,7 +149,7 @@ public class DataciteService {
     private DataciteServiceException createDoiGetFailedException(int status, String cause) {
         String message = "GET doi failed: HTTP error code: " + status + "\\n + cause" + cause;
         if (isUserError(status)) {
-            return new DataciteBadRequestException(message, status);
+            return new DataciteUserErrorException(message, status);
         }
         return new DataciteServiceException(message, status);
     }
@@ -177,7 +177,7 @@ public class DataciteService {
     private DataciteServiceException createPostFailedException(String kind, int status, String cause) {
         String message = kind + " post failed : HTTP error code : " + status + "\n" + cause;
         if (isUserError(status)) {
-            return new DataciteBadRequestException(message, status);
+            return new DataciteUserErrorException(message, status);
         }
         return new DataciteServiceException(message, status);
     }

--- a/src/main/java/nl/knaw/dans/easy/DataciteService.java
+++ b/src/main/java/nl/knaw/dans/easy/DataciteService.java
@@ -71,23 +71,6 @@ public class DataciteService {
         logger.info(message);
     }
 
-    private String postDoi(String content) throws DataciteServiceException {
-        try {
-            logger.debug("THIS IS SENT TO DATACITE: {}", content);
-            ClientResponse response = createDoiWebResource().type(configuration.getDoiRegistrationContentType()).post(ClientResponse.class, content);
-            String entity = response.getEntity(String.class);
-            if (response.getStatus() != CREATED.getStatusCode())
-                throw createDoiPostFailedException(response.getStatus(), entity);
-            return entity;
-        }
-        catch (UniformInterfaceException e) {
-            throw createDoiPostFailedException(e);
-        }
-        catch (ClientHandlerException e) {
-            throw createDoiPostFailedException(e);
-        }
-    }
-
     public boolean doiExists(String doi) throws DataciteServiceException {
         try {
             String uri = configuration.getDoiRegistrationUri() + "/" + doi;
@@ -107,6 +90,27 @@ public class DataciteService {
         catch (DataciteServiceException e) {
             throw createDoiGetFailedException(e);
         }
+    }
+
+    private String postDoi(String content) throws DataciteServiceException {
+        try {
+            logger.debug("THIS IS SENT TO DATACITE: {}", content);
+            ClientResponse response = createDoiWebResource().type(configuration.getDoiRegistrationContentType()).post(ClientResponse.class, content);
+            String entity = response.getEntity(String.class);
+            if (response.getStatus() != CREATED.getStatusCode())
+                throw createDoiPostFailedException(response.getStatus(), entity);
+            return entity;
+        }
+        catch (UniformInterfaceException e) {
+            throw createDoiPostFailedException(e);
+        }
+        catch (ClientHandlerException e) {
+            throw createDoiPostFailedException(e);
+        }
+    }
+
+    private boolean isUserError(int statusCode) {
+        return (statusCode >= 400) && (statusCode < 500);
     }
 
     private String postMetadata(String content) throws DataciteServiceException {
@@ -143,7 +147,11 @@ public class DataciteService {
     }
 
     private DataciteServiceException createDoiGetFailedException(int status, String cause) {
-        return new DataciteServiceException("GET doi failed: HTTP error code " + status + " and cause: " + cause);
+        String message = "GET doi failed: HTTP error code: " + status + "\\n + cause" + cause;
+        if (isUserError(status)) {
+            return new DataciteBadRequestException(message, status);
+        }
+        return new DataciteServiceException(message, status);
     }
 
     private DataciteServiceException createDoiGetFailedException(Exception cause) {
@@ -167,7 +175,11 @@ public class DataciteService {
     }
 
     private DataciteServiceException createPostFailedException(String kind, int status, String cause) {
-        return new DataciteServiceException(kind + " post failed : HTTP error code : " + status + "\n" + cause);
+        String message = kind + " post failed : HTTP error code : " + status + "\n" + cause;
+        if (isUserError(status)) {
+            return new DataciteBadRequestException(message, status);
+        }
+        return new DataciteServiceException(message, status);
     }
 
     private DataciteServiceException createPostFailedException(String kind, Exception cause) {

--- a/src/main/java/nl/knaw/dans/easy/DataciteServiceException.java
+++ b/src/main/java/nl/knaw/dans/easy/DataciteServiceException.java
@@ -18,7 +18,7 @@ package nl.knaw.dans.easy;
 public class DataciteServiceException extends Exception {
 
     private static final long serialVersionUID = 1L;
-    protected int httpStatusCode = 0;
+    private int httpStatusCode = 0;
 
     public DataciteServiceException(String message, Exception cause) {
         super(message, cause);

--- a/src/main/java/nl/knaw/dans/easy/DataciteUserErrorException.java
+++ b/src/main/java/nl/knaw/dans/easy/DataciteUserErrorException.java
@@ -18,6 +18,5 @@ package nl.knaw.dans.easy;
 public class DataciteUserErrorException extends DataciteServiceException {
     public DataciteUserErrorException(String message, int httpStatusCode) {
         super(message, httpStatusCode);
-        this.httpStatusCode = httpStatusCode;
     }
 }

--- a/src/main/java/nl/knaw/dans/easy/DataciteUserErrorException.java
+++ b/src/main/java/nl/knaw/dans/easy/DataciteUserErrorException.java
@@ -15,8 +15,8 @@
  */
 package nl.knaw.dans.easy;
 
-public class DataciteBadRequestException extends DataciteServiceException {
-    public DataciteBadRequestException(String message, int httpStatusCode) {
+public class DataciteUserErrorException extends DataciteServiceException {
+    public DataciteUserErrorException(String message, int httpStatusCode) {
         super(message, httpStatusCode);
         this.httpStatusCode = httpStatusCode;
     }


### PR DESCRIPTION
fixes EASY-1762

#### When applied it will
*  add the httpStatusCode as separate field to the DataciteServiceException
* add a subException DataciteUserErrorException if an exception is caused by a 400 range statuscode

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?
* build the project (online tests are ignored when the credentials for DataCite are not specified)

#### related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ---
easy-ingest-flow                      | [PR#87](https://github.com/DANS-KNAW/easy-ingest-flow/pull/87)     | 
