### PR TITLE
EASY-1831: aanpassen NO_ACCESS uitlevering in OAI-formaten

### DIFF
--- a/src/main/resources/xslt-files/EMD_doi_datacite_v4.1.xsl
+++ b/src/main/resources/xslt-files/EMD_doi_datacite_v4.1.xsl
@@ -817,7 +817,7 @@
          info:eu-repo/semantics/openAccess
         -->
         <xsl:variable name="doi" select="//emd:identifier/dc:identifier[@eas:scheme='DOI']/text()"/>
-        <xsl:variable name="origin-doi" select="if (starts-with($doi, '10.5072/dans-')) then 'DANS' else 'OTHER'"/>
+        <xsl:variable name="origin-doi" select="if (starts-with($doi, '10.17026/dans-')) then 'DANS' else 'OTHER'"/>
         <xsl:element name="rights">
             <xsl:choose>
                 <xsl:when test=". = 'OPEN_ACCESS_FOR_REGISTERED_USERS'">

--- a/src/main/resources/xslt-files/EMD_doi_datacite_v4.1.xsl
+++ b/src/main/resources/xslt-files/EMD_doi_datacite_v4.1.xsl
@@ -782,7 +782,7 @@
         <xsl:variable name="access-rights" select="dcterms:accessRights"/>
         <xsl:variable name="licenses" select="dcterms:license"/>
         <xsl:variable name="doi" select="//emd:identifier/dc:identifier[@eas:scheme='DOI']/text()"/>
-        <xsl:variable name="origin-doi" select="if (starts-with($doi, '10.17026/dans-')) then 'DANS' else 'OTHER'"/>
+        <xsl:variable name="origin-doi" select="if (starts-with($doi, '10.17026/')) then 'DANS' else 'OTHER'"/>
         <xsl:variable name="access-rights-datacite">
             <xsl:choose>
                 <xsl:when test="$access-rights ='NO_ACCESS' and $origin-doi != 'DANS'">
@@ -822,7 +822,7 @@
         <xsl:if test="$licenses">
             <xsl:for-each select="$licenses">
                 <xsl:choose>
-                    <xsl:when test=". = 'accept' and $access-rights-datacite = 'OPEN_ACCESS'">
+                    <xsl:when test=". = 'accept' and ../dcterms:accessRights = 'OPEN_ACCESS'">
                         <xsl:variable name="cc0" select="'http://creativecommons.org/publicdomain/zero/1.0'"/>
                         <xsl:element name="rights">
                             <xsl:attribute name="rightsURI" select="$cc0"/>

--- a/src/main/resources/xslt-files/EMD_doi_datacite_v4.1.xsl
+++ b/src/main/resources/xslt-files/EMD_doi_datacite_v4.1.xsl
@@ -816,6 +816,8 @@
          info:eu-repo/semantics/restrictedAccess
          info:eu-repo/semantics/openAccess
         -->
+        <xsl:variable name="doi" select="//emd:identifier/dc:identifier[@eas:scheme='DOI']/text()"/>
+        <xsl:variable name="origin-doi" select="if (starts-with($doi, '10.5072/dans-')) then 'DANS' else 'OTHER'"/>
         <xsl:element name="rights">
             <xsl:choose>
                 <xsl:when test=". = 'OPEN_ACCESS_FOR_REGISTERED_USERS'">
@@ -829,6 +831,9 @@
                 </xsl:when>
                 <xsl:when test=". = 'REQUEST_PERMISSION'">
                     <xsl:value-of select="'info:eu-repo/semantics/restrictedAccess'"/>
+                </xsl:when>
+                <xsl:when test=". = 'NO_ACCESS' and $origin-doi != 'DANS'">
+                    <xsl:value-of select="'info:eu-repo/semantics/openAccess'"/>
                 </xsl:when>
                 <xsl:when test=". = 'NO_ACCESS'">
                     <xsl:value-of select="'info:eu-repo/semantics/closedAccess'"/>

--- a/src/main/resources/xslt-files/EMD_doi_datacite_v4.1.xsl
+++ b/src/main/resources/xslt-files/EMD_doi_datacite_v4.1.xsl
@@ -779,13 +779,50 @@
     <!-- emd:rights/dct:accessRights to datacite rights -->
     <!-- ==================================================== -->
     <xsl:template match="emd:rights">
-        <xsl:apply-templates select="dcterms:accessRights"/>
-
+        <xsl:variable name="access-rights" select="dcterms:accessRights"/>
         <xsl:variable name="licenses" select="dcterms:license"/>
+        <xsl:variable name="doi" select="//emd:identifier/dc:identifier[@eas:scheme='DOI']/text()"/>
+        <xsl:variable name="origin-doi" select="if (starts-with($doi, '10.17026/dans-')) then 'DANS' else 'OTHER'"/>
+        <xsl:variable name="access-rights-datacite">
+            <xsl:choose>
+                <xsl:when test="$access-rights ='NO_ACCESS' and $origin-doi != 'DANS'">
+                    <xsl:value-of select="'OPEN_ACCESS'"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="$access-rights"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+
+        <xsl:if test="$access-rights">
+            <xsl:element name="rights">
+                <xsl:choose>
+                    <xsl:when test="$access-rights-datacite = 'OPEN_ACCESS_FOR_REGISTERED_USERS'">
+                        <xsl:value-of select="'info:eu-repo/semantics/openAccess'"/>
+                    </xsl:when>
+                    <xsl:when test="$access-rights-datacite = 'OPEN_ACCESS'">
+                        <xsl:value-of select="'info:eu-repo/semantics/openAccess'"/>
+                    </xsl:when>
+                    <xsl:when test="$access-rights-datacite = 'GROUP_ACCESS'">
+                        <xsl:value-of select="'info:eu-repo/semantics/restrictedAccess'"/>
+                    </xsl:when>
+                    <xsl:when test="$access-rights-datacite = 'REQUEST_PERMISSION'">
+                        <xsl:value-of select="'info:eu-repo/semantics/restrictedAccess'"/>
+                    </xsl:when>
+                    <xsl:when test="$access-rights-datacite = 'NO_ACCESS'">
+                        <xsl:value-of select="'info:eu-repo/semantics/closedAccess'"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:value-of select="."/>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:element>
+        </xsl:if>
+
         <xsl:if test="$licenses">
             <xsl:for-each select="$licenses">
                 <xsl:choose>
-                    <xsl:when test=". = 'accept' and ../dcterms:accessRights = 'OPEN_ACCESS'">
+                    <xsl:when test=". = 'accept' and $access-rights-datacite = 'OPEN_ACCESS'">
                         <xsl:variable name="cc0" select="'http://creativecommons.org/publicdomain/zero/1.0'"/>
                         <xsl:element name="rights">
                             <xsl:attribute name="rightsURI" select="$cc0"/>
@@ -807,42 +844,6 @@
                 </xsl:choose>
             </xsl:for-each>
         </xsl:if>
-    </xsl:template>
-
-    <xsl:template match="dcterms:accessRights">
-        <!-- 
-         info:eu-repo/semantics/closedAccess
-         info:eu-repo/semantics/embargoedAccess
-         info:eu-repo/semantics/restrictedAccess
-         info:eu-repo/semantics/openAccess
-        -->
-        <xsl:variable name="doi" select="//emd:identifier/dc:identifier[@eas:scheme='DOI']/text()"/>
-        <xsl:variable name="origin-doi" select="if (starts-with($doi, '10.17026/dans-')) then 'DANS' else 'OTHER'"/>
-        <xsl:element name="rights">
-            <xsl:choose>
-                <xsl:when test=". = 'OPEN_ACCESS_FOR_REGISTERED_USERS'">
-                    <xsl:value-of select="'info:eu-repo/semantics/openAccess'"/>
-                </xsl:when>
-                <xsl:when test=". = 'OPEN_ACCESS'">
-                    <xsl:value-of select="'info:eu-repo/semantics/openAccess'"/>
-                </xsl:when>
-                <xsl:when test=". = 'GROUP_ACCESS'">
-                    <xsl:value-of select="'info:eu-repo/semantics/restrictedAccess'"/>
-                </xsl:when>
-                <xsl:when test=". = 'REQUEST_PERMISSION'">
-                    <xsl:value-of select="'info:eu-repo/semantics/restrictedAccess'"/>
-                </xsl:when>
-                <xsl:when test=". = 'NO_ACCESS' and $origin-doi != 'DANS'">
-                    <xsl:value-of select="'info:eu-repo/semantics/openAccess'"/>
-                </xsl:when>
-                <xsl:when test=". = 'NO_ACCESS'">
-                    <xsl:value-of select="'info:eu-repo/semantics/closedAccess'"/>
-                </xsl:when>
-                <xsl:otherwise>
-                    <xsl:value-of select="."/>
-                </xsl:otherwise>
-            </xsl:choose>
-        </xsl:element>
     </xsl:template>
 
     <!-- ==================================================== -->

--- a/src/main/resources/xslt-files/EMD_doi_datacite_v4.xsl
+++ b/src/main/resources/xslt-files/EMD_doi_datacite_v4.xsl
@@ -791,7 +791,7 @@
          info:eu-repo/semantics/openAccess
         -->
         <xsl:variable name="doi" select="//emd:identifier/dc:identifier[@eas:scheme='DOI']/text()"/>
-        <xsl:variable name="origin-doi" select="if (starts-with($doi, '10.5072/dans-')) then 'DANS' else 'OTHER'"/>
+        <xsl:variable name="origin-doi" select="if (starts-with($doi, '10.17026/dans-')) then 'DANS' else 'OTHER'"/>
         <xsl:element name="rights">
             <xsl:choose>
                 <xsl:when test=". = 'OPEN_ACCESS_FOR_REGISTERED_USERS'">

--- a/src/main/resources/xslt-files/EMD_doi_datacite_v4.xsl
+++ b/src/main/resources/xslt-files/EMD_doi_datacite_v4.xsl
@@ -753,13 +753,50 @@
     <!-- emd:rights/dct:accessRights to datacite rights -->
     <!-- ==================================================== -->
     <xsl:template match="emd:rights">
-        <xsl:apply-templates select="dcterms:accessRights"/>
-
+        <xsl:variable name="access-rights" select="dcterms:accessRights"/>
         <xsl:variable name="licenses" select="dcterms:license"/>
+        <xsl:variable name="doi" select="//emd:identifier/dc:identifier[@eas:scheme='DOI']/text()"/>
+        <xsl:variable name="origin-doi" select="if (starts-with($doi, '10.17026/dans-')) then 'DANS' else 'OTHER'"/>
+        <xsl:variable name="access-rights-datacite">
+            <xsl:choose>
+                <xsl:when test="$access-rights ='NO_ACCESS' and $origin-doi != 'DANS'">
+                    <xsl:value-of select="'OPEN_ACCESS'"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="$access-rights"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+
+        <xsl:if test="$access-rights">
+            <xsl:element name="rights">
+                <xsl:choose>
+                    <xsl:when test="$access-rights-datacite = 'OPEN_ACCESS_FOR_REGISTERED_USERS'">
+                        <xsl:value-of select="'info:eu-repo/semantics/openAccess'"/>
+                    </xsl:when>
+                    <xsl:when test="$access-rights-datacite = 'OPEN_ACCESS'">
+                        <xsl:value-of select="'info:eu-repo/semantics/openAccess'"/>
+                    </xsl:when>
+                    <xsl:when test="$access-rights-datacite = 'GROUP_ACCESS'">
+                        <xsl:value-of select="'info:eu-repo/semantics/restrictedAccess'"/>
+                    </xsl:when>
+                    <xsl:when test="$access-rights-datacite = 'REQUEST_PERMISSION'">
+                        <xsl:value-of select="'info:eu-repo/semantics/restrictedAccess'"/>
+                    </xsl:when>
+                    <xsl:when test="$access-rights-datacite = 'NO_ACCESS'">
+                        <xsl:value-of select="'info:eu-repo/semantics/closedAccess'"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:value-of select="."/>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:element>
+        </xsl:if>
+
         <xsl:if test="$licenses">
             <xsl:for-each select="$licenses">
                 <xsl:choose>
-                    <xsl:when test=". = 'accept' and ../dcterms:accessRights = 'OPEN_ACCESS'">
+                    <xsl:when test=". = 'accept' and $access-rights-datacite = 'OPEN_ACCESS'">
                         <xsl:variable name="cc0" select="'http://creativecommons.org/publicdomain/zero/1.0'"/>
                         <xsl:element name="rights">
                             <xsl:attribute name="rightsURI" select="$cc0"/>
@@ -781,42 +818,6 @@
                 </xsl:choose>
             </xsl:for-each>
         </xsl:if>
-    </xsl:template>
-
-    <xsl:template match="dcterms:accessRights">
-        <!-- 
-         info:eu-repo/semantics/closedAccess
-         info:eu-repo/semantics/embargoedAccess
-         info:eu-repo/semantics/restrictedAccess
-         info:eu-repo/semantics/openAccess
-        -->
-        <xsl:variable name="doi" select="//emd:identifier/dc:identifier[@eas:scheme='DOI']/text()"/>
-        <xsl:variable name="origin-doi" select="if (starts-with($doi, '10.17026/dans-')) then 'DANS' else 'OTHER'"/>
-        <xsl:element name="rights">
-            <xsl:choose>
-                <xsl:when test=". = 'OPEN_ACCESS_FOR_REGISTERED_USERS'">
-                    <xsl:value-of select="'info:eu-repo/semantics/openAccess'"/>
-                </xsl:when>
-                <xsl:when test=". = 'OPEN_ACCESS'">
-                    <xsl:value-of select="'info:eu-repo/semantics/openAccess'"/>
-                </xsl:when>
-                <xsl:when test=". = 'GROUP_ACCESS'">
-                    <xsl:value-of select="'info:eu-repo/semantics/restrictedAccess'"/>
-                </xsl:when>
-                <xsl:when test=". = 'REQUEST_PERMISSION'">
-                    <xsl:value-of select="'info:eu-repo/semantics/restrictedAccess'"/>
-                </xsl:when>
-                <xsl:when test=". = 'NO_ACCESS' and $origin-doi != 'DANS'">
-                    <xsl:value-of select="'info:eu-repo/semantics/openAccess'"/>
-                </xsl:when>
-                <xsl:when test=". = 'NO_ACCESS'">
-                    <xsl:value-of select="'info:eu-repo/semantics/closedAccess'"/>
-                </xsl:when>
-                <xsl:otherwise>
-                    <xsl:value-of select="."/>
-                </xsl:otherwise>
-            </xsl:choose>
-        </xsl:element>
     </xsl:template>
 
     <!-- ==================================================== -->

--- a/src/main/resources/xslt-files/EMD_doi_datacite_v4.xsl
+++ b/src/main/resources/xslt-files/EMD_doi_datacite_v4.xsl
@@ -756,7 +756,7 @@
         <xsl:variable name="access-rights" select="dcterms:accessRights"/>
         <xsl:variable name="licenses" select="dcterms:license"/>
         <xsl:variable name="doi" select="//emd:identifier/dc:identifier[@eas:scheme='DOI']/text()"/>
-        <xsl:variable name="origin-doi" select="if (starts-with($doi, '10.17026/dans-')) then 'DANS' else 'OTHER'"/>
+        <xsl:variable name="origin-doi" select="if (starts-with($doi, '10.17026/')) then 'DANS' else 'OTHER'"/>
         <xsl:variable name="access-rights-datacite">
             <xsl:choose>
                 <xsl:when test="$access-rights ='NO_ACCESS' and $origin-doi != 'DANS'">
@@ -796,7 +796,7 @@
         <xsl:if test="$licenses">
             <xsl:for-each select="$licenses">
                 <xsl:choose>
-                    <xsl:when test=". = 'accept' and $access-rights-datacite = 'OPEN_ACCESS'">
+                    <xsl:when test=". = 'accept' and ../dcterms:accessRights = 'OPEN_ACCESS'">
                         <xsl:variable name="cc0" select="'http://creativecommons.org/publicdomain/zero/1.0'"/>
                         <xsl:element name="rights">
                             <xsl:attribute name="rightsURI" select="$cc0"/>

--- a/src/main/resources/xslt-files/EMD_doi_datacite_v4.xsl
+++ b/src/main/resources/xslt-files/EMD_doi_datacite_v4.xsl
@@ -790,6 +790,8 @@
          info:eu-repo/semantics/restrictedAccess
          info:eu-repo/semantics/openAccess
         -->
+        <xsl:variable name="doi" select="//emd:identifier/dc:identifier[@eas:scheme='DOI']/text()"/>
+        <xsl:variable name="origin-doi" select="if (starts-with($doi, '10.5072/dans-')) then 'DANS' else 'OTHER'"/>
         <xsl:element name="rights">
             <xsl:choose>
                 <xsl:when test=". = 'OPEN_ACCESS_FOR_REGISTERED_USERS'">
@@ -803,6 +805,9 @@
                 </xsl:when>
                 <xsl:when test=". = 'REQUEST_PERMISSION'">
                     <xsl:value-of select="'info:eu-repo/semantics/restrictedAccess'"/>
+                </xsl:when>
+                <xsl:when test=". = 'NO_ACCESS' and $origin-doi != 'DANS'">
+                    <xsl:value-of select="'info:eu-repo/semantics/openAccess'"/>
                 </xsl:when>
                 <xsl:when test=". = 'NO_ACCESS'">
                     <xsl:value-of select="'info:eu-repo/semantics/closedAccess'"/>

--- a/src/test/java/nl/knaw/dans/easy/DataciteResourcesBuilderTest.java
+++ b/src/test/java/nl/knaw/dans/easy/DataciteResourcesBuilderTest.java
@@ -144,6 +144,28 @@ public class DataciteResourcesBuilderTest {
     }
 
     @Test
+    public void noAccessWithDansDoi() throws Exception {
+        EasyMetadata emd = new EmdBuilder("no-access-dans-doi-emd.xml").build();
+
+        DataciteResourcesBuilder.Resources out = createDefaultBuilder().create(emd);
+        String metadataOut = out.metadataResource;
+
+        assertThat(metadataOut, containsString("<rights>info:eu-repo/semantics/closedAccess</rights>"));
+        logger.debug(metadataOut);
+    }
+
+    @Test
+    public void noAccessWithOtherDoi() throws Exception {
+        EasyMetadata emd = new EmdBuilder("no-access-other-doi-emd.xml").build();
+
+        DataciteResourcesBuilder.Resources out = createDefaultBuilder().create(emd);
+        String metadataOut = out.metadataResource;
+
+        assertThat(metadataOut, containsString("<rights>info:eu-repo/semantics/openAccess</rights>"));
+        logger.debug(metadataOut);
+    }
+
+    @Test
     public void creatorAffiliation() throws Exception {
         ignoreIfNot("kernel-" + version);
 

--- a/src/test/resources/no-access-dans-doi-emd.xml
+++ b/src/test/resources/no-access-dans-doi-emd.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<emd:easymetadata xmlns:emd="http://easy.dans.knaw.nl/easy/easymetadata/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:eas="http://easy.dans.knaw.nl/easy/easymetadata/eas/" emd:version="0.1">
+    <emd:title>
+        <dc:title>test-title</dc:title>
+        <dct:alternative>test-alternative-title</dct:alternative>
+        <dct:alternative>test-alternative-title2</dct:alternative>
+    </emd:title>
+    <emd:creator>
+        <eas:creator>
+            <eas:initials>X</eas:initials>
+            <eas:surname>Foo</eas:surname>
+            <eas:organization>International Atomic Energy Agency</eas:organization>
+            <eas:entityId eas:scheme="DAI">someDai</eas:entityId>
+        </eas:creator>
+    </emd:creator>
+    <emd:subject>
+        <dc:subject>PROSPECTIE</dc:subject>
+        <dc:subject>NIEUWE TIJD</dc:subject>
+        <dc:subject>BEWONING</dc:subject>
+        <dc:subject eas:scheme="ABR" eas:schemeId="archaeology.dc.subject">GX</dc:subject>
+    </emd:subject>
+    <emd:description>
+        <dc:description>test-description</dc:description>
+    </emd:description>
+    <emd:publisher>
+        <dc:publisher>test-publisher</dc:publisher>
+    </emd:publisher>
+    <emd:contributor>
+        <eas:contributor>
+            <eas:initials>Y</eas:initials>
+            <eas:surname>Baar</eas:surname>
+            <eas:organization>CERN</eas:organization>
+            <eas:entityId eas:scheme="DAI"></eas:entityId>
+        </eas:contributor>
+    </emd:contributor>
+    <emd:date>
+        <eas:created eas:scheme="W3CDTF" eas:format="YEAR">2002-01-01T00:00:00.000+01:00</eas:created>
+        <eas:available eas:scheme="W3CDTF" eas:format="DAY">2010-01-07T00:00:00.000+01:00</eas:available>
+        <eas:dateSubmitted eas:scheme="W3CDTF" eas:format="DAY">2010-01-11T09:15:12.000+01:00</eas:dateSubmitted>
+    </emd:date>
+    <emd:type>
+        <dc:type>rapport</dc:type>
+        <dc:type eas:scheme="DCMI" eas:schemeId="common.dc.type">Text</dc:type>
+    </emd:type>
+    <emd:format>
+        <dc:format>test-format</dc:format>
+    </emd:format>
+    <emd:identifier>
+        <dc:identifier>test-identifier</dc:identifier>
+        <dc:identifier eas:scheme="ISBN">9077000232</dc:identifier>
+        <dc:identifier eas:scheme="eDNA-project">a07223</dc:identifier>
+        <dc:identifier eas:scheme="AIP_ID">twips.dans.knaw.nl-7865083291377881651-1263201312524</dc:identifier>
+        <dc:identifier eas:scheme="PID" eas:identification-system="http://www.persistent-identifier.nl">urn:nbn:nl:ui:13-sba-6zn</dc:identifier>
+        <dc:identifier eas:scheme="DMO_ID">easy-dataset:1</dc:identifier>
+        <dc:identifier eas:scheme="DOI" eas:identification-system="https://doi.org">10.5072/dans-test-123</dc:identifier>
+        <dc:identifier eas:scheme="DOI_OTHER_ACCESS" eas:identification-system="https://doi.org">10.5072/other-test-123</dc:identifier>
+    </emd:identifier>
+    <emd:source/>
+    <emd:language>
+        <dc:language>test-language</dc:language>
+        <dc:language eas:scheme="ISO 639" eas:schemeId="common.dc.language">dut/nld</dc:language>
+    </emd:language>
+    <emd:relation>
+        <eas:isPartOf>
+            <eas:subject-title>test-partof-subject-title</eas:subject-title>
+            <eas:subject-link/>
+        </eas:isPartOf>
+        <eas:isPartOf>
+            <eas:subject-title>test-partof-subject-title2</eas:subject-title>
+            <eas:subject-link/>
+        </eas:isPartOf>
+    </emd:relation>
+    <emd:coverage>
+        <dct:spatial>Overijssel</dct:spatial>
+        <dct:spatial>Nederland</dct:spatial>
+        <dct:spatial>e-ne (MARC21)</dct:spatial>
+        <dct:temporal eas:scheme="ABR" eas:schemeId="archaeology.dcterms.temporal">NT</dct:temporal>
+        <eas:spatial>
+            <eas:point eas:scheme="RD">
+                <eas:x>171872</eas:x>
+                <eas:y>584275</eas:y>
+            </eas:point>
+            <eas:box eas:scheme="RD">
+                <eas:north>359400</eas:north>
+                <eas:east>196100</eas:east>
+                <eas:south>354000</eas:south>
+                <eas:west>191450</eas:west>
+            </eas:box>
+        </eas:spatial>
+    </emd:coverage>
+    <emd:rights>
+        <dct:accessRights eas:schemeId="common.dcterms.accessrights">NO_ACCESS</dct:accessRights>
+        <dct:rightsHolder>test-rightsholder</dct:rightsHolder>
+    </emd:rights>
+    <emd:audience>
+        <dct:audience eas:schemeId="custom.disciplines">easy-discipline:2</dct:audience>
+    </emd:audience>
+    <emd:other>
+        <eas:application-specific>
+            <eas:metadataformat>ARCHAEOLOGY</eas:metadataformat>
+        </eas:application-specific>
+        <eas:etc>
+            <property-list>
+                <comment>Conversion of EasyI to EasyII</comment>
+                <entry key="conversion.date">2011-03-31T17:29:41.661Z</entry>
+                <entry key="previous.collection-id">twips.dans.knaw.nl-7865083291377881651-1263201312524</entry>
+            </property-list>
+        </eas:etc>
+    </emd:other>
+</emd:easymetadata>

--- a/src/test/resources/no-access-dans-doi-emd.xml
+++ b/src/test/resources/no-access-dans-doi-emd.xml
@@ -52,7 +52,7 @@
         <dc:identifier eas:scheme="AIP_ID">twips.dans.knaw.nl-7865083291377881651-1263201312524</dc:identifier>
         <dc:identifier eas:scheme="PID" eas:identification-system="http://www.persistent-identifier.nl">urn:nbn:nl:ui:13-sba-6zn</dc:identifier>
         <dc:identifier eas:scheme="DMO_ID">easy-dataset:1</dc:identifier>
-        <dc:identifier eas:scheme="DOI" eas:identification-system="https://doi.org">10.5072/dans-test-123</dc:identifier>
+        <dc:identifier eas:scheme="DOI" eas:identification-system="https://doi.org">10.17026/dans-123</dc:identifier>
         <dc:identifier eas:scheme="DOI_OTHER_ACCESS" eas:identification-system="https://doi.org">10.5072/other-test-123</dc:identifier>
     </emd:identifier>
     <emd:source/>

--- a/src/test/resources/no-access-other-doi-emd.xml
+++ b/src/test/resources/no-access-other-doi-emd.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<emd:easymetadata xmlns:emd="http://easy.dans.knaw.nl/easy/easymetadata/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:eas="http://easy.dans.knaw.nl/easy/easymetadata/eas/" emd:version="0.1">
+    <emd:title>
+        <dc:title>test-title</dc:title>
+        <dct:alternative>test-alternative-title</dct:alternative>
+        <dct:alternative>test-alternative-title2</dct:alternative>
+    </emd:title>
+    <emd:creator>
+        <eas:creator>
+            <eas:initials>X</eas:initials>
+            <eas:surname>Foo</eas:surname>
+            <eas:organization>International Atomic Energy Agency</eas:organization>
+            <eas:entityId eas:scheme="DAI">someDai</eas:entityId>
+        </eas:creator>
+    </emd:creator>
+    <emd:subject>
+        <dc:subject>PROSPECTIE</dc:subject>
+        <dc:subject>NIEUWE TIJD</dc:subject>
+        <dc:subject>BEWONING</dc:subject>
+        <dc:subject eas:scheme="ABR" eas:schemeId="archaeology.dc.subject">GX</dc:subject>
+    </emd:subject>
+    <emd:description>
+        <dc:description>test-description</dc:description>
+    </emd:description>
+    <emd:publisher>
+        <dc:publisher>test-publisher</dc:publisher>
+    </emd:publisher>
+    <emd:contributor>
+        <eas:contributor>
+            <eas:initials>Y</eas:initials>
+            <eas:surname>Baar</eas:surname>
+            <eas:organization>CERN</eas:organization>
+            <eas:entityId eas:scheme="DAI"></eas:entityId>
+        </eas:contributor>
+    </emd:contributor>
+    <emd:date>
+        <eas:created eas:scheme="W3CDTF" eas:format="YEAR">2002-01-01T00:00:00.000+01:00</eas:created>
+        <eas:available eas:scheme="W3CDTF" eas:format="DAY">2010-01-07T00:00:00.000+01:00</eas:available>
+        <eas:dateSubmitted eas:scheme="W3CDTF" eas:format="DAY">2010-01-11T09:15:12.000+01:00</eas:dateSubmitted>
+    </emd:date>
+    <emd:type>
+        <dc:type>rapport</dc:type>
+        <dc:type eas:scheme="DCMI" eas:schemeId="common.dc.type">Text</dc:type>
+    </emd:type>
+    <emd:format>
+        <dc:format>test-format</dc:format>
+    </emd:format>
+    <emd:identifier>
+        <dc:identifier>test-identifier</dc:identifier>
+        <dc:identifier eas:scheme="ISBN">9077000232</dc:identifier>
+        <dc:identifier eas:scheme="eDNA-project">a07223</dc:identifier>
+        <dc:identifier eas:scheme="AIP_ID">twips.dans.knaw.nl-7865083291377881651-1263201312524</dc:identifier>
+        <dc:identifier eas:scheme="PID" eas:identification-system="http://www.persistent-identifier.nl">urn:nbn:nl:ui:13-sba-6zn</dc:identifier>
+        <dc:identifier eas:scheme="DMO_ID">easy-dataset:1</dc:identifier>
+        <dc:identifier eas:scheme="DOI" eas:identification-system="https://doi.org">11.111/other-doi-123</dc:identifier>
+        <dc:identifier eas:scheme="DOI_OTHER_ACCESS" eas:identification-system="https://doi.org">10.5072/other-test-123</dc:identifier>
+    </emd:identifier>
+    <emd:source/>
+    <emd:language>
+        <dc:language>test-language</dc:language>
+        <dc:language eas:scheme="ISO 639" eas:schemeId="common.dc.language">dut/nld</dc:language>
+    </emd:language>
+    <emd:relation>
+        <eas:isPartOf>
+            <eas:subject-title>test-partof-subject-title</eas:subject-title>
+            <eas:subject-link/>
+        </eas:isPartOf>
+        <eas:isPartOf>
+            <eas:subject-title>test-partof-subject-title2</eas:subject-title>
+            <eas:subject-link/>
+        </eas:isPartOf>
+    </emd:relation>
+    <emd:coverage>
+        <dct:spatial>Overijssel</dct:spatial>
+        <dct:spatial>Nederland</dct:spatial>
+        <dct:spatial>e-ne (MARC21)</dct:spatial>
+        <dct:temporal eas:scheme="ABR" eas:schemeId="archaeology.dcterms.temporal">NT</dct:temporal>
+        <eas:spatial>
+            <eas:point eas:scheme="RD">
+                <eas:x>171872</eas:x>
+                <eas:y>584275</eas:y>
+            </eas:point>
+            <eas:box eas:scheme="RD">
+                <eas:north>359400</eas:north>
+                <eas:east>196100</eas:east>
+                <eas:south>354000</eas:south>
+                <eas:west>191450</eas:west>
+            </eas:box>
+        </eas:spatial>
+    </emd:coverage>
+    <emd:rights>
+        <dct:accessRights eas:schemeId="common.dcterms.accessrights">NO_ACCESS</dct:accessRights>
+        <dct:rightsHolder>test-rightsholder</dct:rightsHolder>
+    </emd:rights>
+    <emd:audience>
+        <dct:audience eas:schemeId="custom.disciplines">easy-discipline:2</dct:audience>
+    </emd:audience>
+    <emd:other>
+        <eas:application-specific>
+            <eas:metadataformat>ARCHAEOLOGY</eas:metadataformat>
+        </eas:application-specific>
+        <eas:etc>
+            <property-list>
+                <comment>Conversion of EasyI to EasyII</comment>
+                <entry key="conversion.date">2011-03-31T17:29:41.661Z</entry>
+                <entry key="previous.collection-id">twips.dans.knaw.nl-7865083291377881651-1263201312524</entry>
+            </property-list>
+        </eas:etc>
+    </emd:other>
+</emd:easymetadata>


### PR DESCRIPTION
fixes EASY-1831

#### When applied it will change the way `NO_ACCESS` datasets are presented in OAI-format
* When access category in EMD is `NO_ACCESS` and DOI does `not` originate from DANS, access category is given as `open access`. 
* This change is taken in account also in choosing which license is shown 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?
* build the project
* ingest a bag with NO_ACCESS access rights, first without a specific DOI and then with a DOI, whose prefix does not belong to DANS  (with user `mendeltest` you can give a specific DOI)
* In `http://deasy.dans.knaw.nl/oai/` check the OAI-formats
* In the first case access category should be `no access`, and in the second case `open access`

#### related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ---
easy-dtap                      | [PR#294](https://github.com/DANS-KNAW/easy-dtap/pull/294)     | 
