### PR TITLE
EASY-2578: catch ClientHandlerException in DataCiteService.doiExists

### DIFF
--- a/src/main/java/nl/knaw/dans/easy/DataciteService.java
+++ b/src/main/java/nl/knaw/dans/easy/DataciteService.java
@@ -84,6 +84,9 @@ public class DataciteService {
             } else
                 throw createDoiGetFailedException(status, response.getEntity(String.class));
         }
+        catch (ClientHandlerException e) {
+            throw createDoiGetFailedException(e);
+        }
         catch (UniformInterfaceException e) {
             throw createDoiGetFailedException(e);
         }


### PR DESCRIPTION
fixes EASY-2578

#### When applied it will
* catch `ClientHandlerException` in `DataCiteService.doiExists`

@DANS-KNAW/easy for review