### PR TITLE
EASY-2621: Choose the right user license in the v4.1 export

### DIFF
--- a/src/main/resources/xslt-files/EMD_doi_datacite_v4.1.xsl
+++ b/src/main/resources/xslt-files/EMD_doi_datacite_v4.1.xsl
@@ -828,18 +828,25 @@
                 </xsl:choose>
             </xsl:element>
         </xsl:if>
-
-        <xsl:if test="$licenses">
+        
+        <xsl:variable name="cc0" select="'http://creativecommons.org/publicdomain/zero/1.0'"/>
+        <xsl:variable name="dansLicense" select="'https://dans.knaw.nl/en/about/organisation-and-policy/legal-information/DANSLicence.pdf'"/>
+        <xsl:if test="$licenses">            
             <xsl:for-each select="$licenses">
                 <xsl:choose>
-                    <xsl:when test=". = 'accept' and ../dcterms:accessRights = 'OPEN_ACCESS'">
-                        <xsl:variable name="cc0" select="'http://creativecommons.org/publicdomain/zero/1.0'"/>
+                    <xsl:when test=". = 'accept' and count($licenses) = 1">  
                         <xsl:element name="rights">
-                            <xsl:attribute name="rightsURI" select="$cc0"/>
-                            <xsl:value-of select="concat('License: ', $cc0)"/>
+                            <xsl:if test="$access-rights-datacite = 'OPEN_ACCESS'">
+                                <xsl:attribute name="rightsURI" select="$cc0"/>
+                                <xsl:value-of select="concat('License: ', $cc0)"/>
+                            </xsl:if>
+                            <xsl:if test="not($access-rights-datacite = 'OPEN_ACCESS')">
+                                <xsl:attribute name="rightsURI" select="$dansLicense"/>
+                                <xsl:value-of select="'DANS License'"/>
+                            </xsl:if>
                         </xsl:element>
                     </xsl:when>
-                    <xsl:when test=". = 'accept'"/> <!-- this case is such that the 'accept' value does not end up in the otherwise clause -->
+                    <xsl:when test=". = 'accept'"/><!-- this case is such that the 'accept' value does not end up in the otherwise clause -->
                     <xsl:when test="starts-with(., 'http://') or starts-with(., 'https://')">
                         <xsl:element name="rights">
                             <xsl:attribute name="rightsURI" select="."/>
@@ -853,6 +860,18 @@
                     </xsl:otherwise>
                 </xsl:choose>
             </xsl:for-each>
+        </xsl:if>
+        <xsl:if test="not($licenses)">
+            <xsl:element name="rights">
+                <xsl:if test="$access-rights-datacite = 'OPEN_ACCESS'">
+                    <xsl:attribute name="rightsURI" select="$cc0"/>
+                    <xsl:value-of select="concat('License: ', $cc0)"/>
+                </xsl:if>
+                <xsl:if test="not($access-rights-datacite = 'OPEN_ACCESS')">
+                    <xsl:attribute name="rightsURI" select="$dansLicense"/>
+                    <xsl:value-of select="'DANS License'"/>
+                </xsl:if>
+            </xsl:element>
         </xsl:if>
     </xsl:template>
 


### PR DESCRIPTION
fixes EASY-2621

#### When applied it will
* use CC-0 only when no other license is given and the dataset is open access
* use the Dans Licence when no other license is given and the dataset is not open access
 
#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

  ```mvn clean install -Ddatacite.user=... -Ddatacite.password=...```

#### related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ---
easy-dtap                      | [PR#448](https://github.com/DANS-KNAW/easy-dtap/pull/448)     | 
