### PR TITLE
EASY-1945: upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,8 @@
 
     <properties>
         <easy.emd.version>3.9.0</easy.emd.version>
+        <easy.xml.version>2.19</easy.xml.version>
+        <jersey-client.version>1.19.4</jersey-client.version>
     </properties>
 
     <scm>
@@ -61,7 +63,7 @@
         <dependency>
             <groupId>nl.knaw.dans.easy</groupId>
             <artifactId>xml</artifactId>
-            <version>2.19</version>
+            <version>${easy.xml.version}</version>
         </dependency>
         <dependency>
             <groupId>nl.knaw.dans.easy</groupId>
@@ -76,7 +78,7 @@
         <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-client</artifactId>
-            <version>1.19.4</version>
+            <version>${jersey-client.version}</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-java-project</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0</version>
     </parent>
 
     <groupId>nl.knaw.dans.easy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-client</artifactId>
-            <version>1.8</version>
+            <version>1.19.4</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-java-project</artifactId>
-        <version>6.0.0</version>
+        <version>6.0.1</version>
     </parent>
 
     <groupId>nl.knaw.dans.easy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-java-project</artifactId>
-        <version>5.1.0</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>nl.knaw.dans.easy</groupId>

--- a/src/test/java/nl/knaw/dans/easy/DataciteServiceTest.java
+++ b/src/test/java/nl/knaw/dans/easy/DataciteServiceTest.java
@@ -49,12 +49,12 @@ public class DataciteServiceTest {
 
     private static Logger savedLogger, savedBuilderLogger;
     private Logger loggerMock;
-    private Capture<String> capturedDebugMessage = new Capture<String>();
-    private Capture<Object> capturedDebugArg = new Capture<Object>();
-    private Capture<Object> capturedDebugArg1 = new Capture<Object>();
-    private Capture<Object> capturedDebugArg2 = new Capture<Object>();
-    private Capture<Object[]> capturedDebugArgs = new Capture<Object[]>();
-    private Capture<Throwable> capturedDebugException = new Capture<Throwable>();
+    private Capture<String> capturedDebugMessage = Capture.newInstance();
+    private Capture<Object> capturedDebugArg = Capture.newInstance();
+    private Capture<Object> capturedDebugArg1 = Capture.newInstance();
+    private Capture<Object> capturedDebugArg2 = Capture.newInstance();
+    private Capture<Object[]> capturedDebugArgs = Capture.newInstance();
+    private Capture<Throwable> capturedDebugException = Capture.newInstance();
 
     @BeforeClass
     public static void beforeClass() {
@@ -299,14 +299,14 @@ public class DataciteServiceTest {
     }
 
     private Capture<String> expectLoggedError() {
-        Capture<String> capturedMessage = new Capture<String>();
+        Capture<String> capturedMessage = Capture.newInstance();
         loggerMock.error((capture(capturedMessage)));
         expectLastCall().once();
         return capturedMessage;
     }
 
     private Capture<String> expectLoggedInfo() {
-        Capture<String> capturedMessage = new Capture<String>();
+        Capture<String> capturedMessage = Capture.newInstance();
         loggerMock.info((capture(capturedMessage)));
         expectLastCall().once();
         return capturedMessage;


### PR DESCRIPTION
Fixes EASY-1945

#### When applied it will
* upgrade parent POM version
* move unique dependency versions that aren't included in a parent POM to properties
* change `Capture` initialization in tests

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 