### PR TITLE
EASY-2720: fix nameIdentifierScheme values

### DIFF
--- a/src/main/resources/xslt-files/EMD_doi_datacite_v4.1.xsl
+++ b/src/main/resources/xslt-files/EMD_doi_datacite_v4.1.xsl
@@ -323,7 +323,8 @@
         <!-- is there a DAI? > ID for daiList -->
         <xsl:if test="eas:entityId[@eas:scheme = 'DAI']/text() != ''">
             <xsl:element name="nameIdentifier">
-                <xsl:attribute name="nameIdentifierScheme" select="'info:eu-repo/dai'" />
+                <xsl:attribute name="nameIdentifierScheme" select="'DAI'" />
+                <xsl:attribute name="schemeURI" select="'info:eu-repo/dai'" />
                 <xsl:value-of select="eas:entityId[@eas:scheme = 'DAI']/text()" />
             </xsl:element>
         </xsl:if>
@@ -332,7 +333,8 @@
     <xsl:template name="orcid">
         <xsl:if test="eas:entityId[@eas:scheme = 'ORCID']/text() != ''">
             <xsl:element name="nameIdentifier">
-                <xsl:attribute name="nameIdentifierScheme" select="'https://orcid.org/'" />
+                <xsl:attribute name="nameIdentifierScheme" select="'ORCID'" />
+                <xsl:attribute name="schemeURI" select="'https://orcid.org'" />
                 <xsl:value-of select="eas:entityId[@eas:scheme = 'ORCID']/text()" />
             </xsl:element>
         </xsl:if>
@@ -341,7 +343,8 @@
     <xsl:template name="isni">
         <xsl:if test="eas:entityId[@eas:scheme = 'ISNI']/text() != ''">
             <xsl:element name="nameIdentifier">
-                <xsl:attribute name="nameIdentifierScheme" select="'http://isni.org/isni/'" />
+                <xsl:attribute name="nameIdentifierScheme" select="'ISNI'" />
+                <xsl:attribute name="schemeURI" select="'http://isni.org/'" />
                 <xsl:value-of select="eas:entityId[@eas:scheme = 'ISNI']/text()" />
             </xsl:element>
         </xsl:if>
@@ -350,7 +353,8 @@
     <xsl:template name="organisationalID">
         <xsl:if test="eas:organizationId[@eas:scheme = 'ISNI']/text() != ''">
             <xsl:element name="nameIdentifier">
-                <xsl:attribute name="nameIdentifierScheme" select="'http://isni.org/isni/'" />
+                <xsl:attribute name="nameIdentifierScheme" select="'ISNI'" />
+                <xsl:attribute name="schemeURI" select="'http://isni.org/'" />
                 <xsl:value-of select="eas:organizationId[@eas:scheme = 'ISNI']/text()" />
             </xsl:element>
         </xsl:if>


### PR DESCRIPTION
fixes EASY-2720

#### When applied it will
* fix `nameIdentifierScheme` values

@DANS-KNAW/easy for review

#### After merging:
* Release a new version of the library to Nexus
* Set the new version and it's SHA in `easy-dtap`
* Apply the newly released version to all projects that require `easy-datacite`
* Release and deploy these projects
* use `easy-send-metadata-to-datacite` to send an update of all metadata to DataCite (http://develop.dans.knaw.nl/easy/devops/update-datacite-metadata/)
* regenerate OAI-PMH (http://develop.dans.knaw.nl/easy/devops/oai-pmh-rebuild-cache/)