### PR TITLE
EASY-2875: Switch the x and y coordinate of the RD polygoon

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,14 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
             </plugin>
             <plugin>

--- a/src/main/resources/xslt-files/EMD_doi_datacite_v4.1.xsl
+++ b/src/main/resources/xslt-files/EMD_doi_datacite_v4.1.xsl
@@ -1138,16 +1138,17 @@
             <xsl:element name="geoLocationPolygon">
                 <xsl:for-each select="eas:polygon-point">
                     <xsl:element name="polygonPoint">
+                        <!-- EASY-2875 : the x and y are switched, because they were switched in the input EMD -->
                         <xsl:element name="pointLatitude">
                             <xsl:call-template name="rd-to-lat-long-lat">
-                                <xsl:with-param name="x" select="eas:x"/>
-                                <xsl:with-param name="y" select="eas:y"/>
+                                <xsl:with-param name="x" select="eas:y"/>
+                                <xsl:with-param name="y" select="eas:x"/>
                             </xsl:call-template>
                         </xsl:element>
                         <xsl:element name="pointLongitude">
                             <xsl:call-template name="rd-to-lat-long-lon">
-                                <xsl:with-param name="x" select="eas:x"/>
-                                <xsl:with-param name="y" select="eas:y"/>
+                                <xsl:with-param name="x" select="eas:y"/>
+                                <xsl:with-param name="y" select="eas:x"/>
                             </xsl:call-template>
                         </xsl:element>
                     </xsl:element>


### PR DESCRIPTION
fixes EASY-2875

#### When applied it will
* correct the order of the x,y coordinate in the RD polygoon
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?
* build the project (online tests are ignored when the credentials for DataCite are not specified)

  ```mvn clean install -Ddatacite.user=... -Ddatacite.password=...```

#### related pull requests on github
repo                       | PR                | note
-------------------------- | ----------------- | ---
easy-                      | [PR#](PRlink)     | 
